### PR TITLE
Fix: timer lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,6 @@ p.start();
 
 The last argument (total duration) is optional as in the previous example.
 
-**NOTE:** When using uniform process, setting the inter-arrival time to N ms
-and duration to D ms will yield D/N arrivals as intuitively expected. However,
-stopping the process with `p.stop()` via `setTimeout` with the same N and D
-values will result in D/N-1 arrivals.
-
 ## License
 
 This software is distributed under the terms of the [ISC](http://en.wikipedia.org/wiki/ISC_license) license.

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+require('rolex'); // TODO: use noConflict()
 
 module.exports = {
   uniform: {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Hassy Veldstra <h@artillery.io>",
   "license": "ISC",
   "dependencies": {
+    "rolex": "0.0.1"
   },
   "devDependencies": {
     "istanbul": "^0.3.17",

--- a/test/index.js
+++ b/test/index.js
@@ -55,12 +55,12 @@ tape('Can create a uniform process', function(t) {
     p.stop();
     t.assert(count === 6, 'Correct number of arrivals');
     t.end();
-  }, 2800);
+  }, 2700);
 });
 
 tape('Can create a uniform process with fixed duration', function(t) {
   var count = 0;
-  var p = arrivals.uniform.process(400, 2800);
+  var p = arrivals.uniform.process(400, 2700);
   p.on('arrival', function() {
     t.ok(true, '  got arrival event ' + (++count));
   });


### PR DESCRIPTION
Use `rolex` to fix cumulative timer lag with built-in setInterval.